### PR TITLE
Add watchlist tool registry

### DIFF
--- a/frontend/src/tools.js
+++ b/frontend/src/tools.js
@@ -1,0 +1,61 @@
+// Utility to store simple memory logs
+export const memory = {
+  logs: [],
+  save(entry) {
+    this.logs.push(entry);
+  }
+};
+
+// Basic tool registration
+export const tools = {};
+export function tool(name, { description, parameters, handler }) {
+  tools[name] = { description, parameters, handler };
+}
+
+// Tool definitions
+
+// Identify top gainers over the last 3 minutes.
+tool("top3minMovers", {
+  description: "Identify top gainers over the last 3 minutes.",
+  async handler() {
+    memory.save(`Tool used: top3minMovers [${new Date().toISOString()}]`);
+    // existing logic here
+  }
+});
+
+// Find trending tokens with consecutive gains.
+tool("trendTracker", {
+  description: "Find trending tokens with consecutive gains.",
+  async handler() {
+    memory.save(`Tool used: trendTracker [${new Date().toISOString()}]`);
+    // existing logic here
+  }
+});
+
+// Summarize current watchlist state.
+tool("summarizeWatchlist", {
+  description: "Summarize current watchlist state.",
+  async handler() {
+    memory.save(`Tool used: summarizeWatchlist [${new Date().toISOString()}]`);
+    // existing logic here
+  }
+});
+
+// Generate risk alerts and smart watchlist suggestions.
+tool("smartWatchlistInsights", {
+  description: "Generate risk alerts and smart watchlist suggestions.",
+  async handler() {
+    memory.save(`Tool used: smartWatchlistInsights [${new Date().toISOString()}]`);
+    // existing logic here
+  }
+});
+
+// Answer natural language questions about your watchlist.
+tool("answerWatchlistQuery", {
+  parameters: { input: "string" },
+  description: "Answer natural language questions about your watchlist.",
+  async handler({ input }) {
+    memory.save(`Tool used: answerWatchlistQuery for input \"${input}\" at [${new Date().toISOString()}]`);
+    // existing logic here
+  }
+});


### PR DESCRIPTION
## Summary
- add new tools module under frontend for tracking watchlist actions

## Testing
- `pytest -q`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68893fdd95648329813f7ef1f67a2f27

## Summary by Sourcery

Introduce a new frontend tools module that provides a generic registration API, in-memory logging, and defines initial watchlist-related tools.

New Features:
- Add frontend tools module (tools.js) with a memory-based logger and tool registration API
- Register five watchlist tools for top gainers, trend tracking, watchlist summary, risk alerts, and natural-language queries