### PR TITLE
feat: introduce codex debug panel and trend filtering

### DIFF
--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -2,11 +2,13 @@ import './env-debug.js';
 import React, { useEffect, useState, Suspense } from 'react';
 import { API_ENDPOINTS, fetchData } from './api.js';
 import { WebSocketProvider } from './context/websocketcontext.jsx';
+import { CodexProvider } from './context/CodexContext.jsx';
 import { FiRefreshCw } from 'react-icons/fi';
 // Eager (tiny) components
 import AuthPanel from './components/AuthPanel';
 const IndicatorLegend = React.lazy(() => import('./components/IndicatorLegend.jsx'));
 import AlertsIndicator from './components/AlertsIndicator.jsx';
+import CodexToggle from './components/CodexToggle.jsx';
 
 // Lazy-loaded (code split) heavier UI regions
 const TopBannerScroll = React.lazy(() => import('./components/TopBannerScroll'));
@@ -93,6 +95,7 @@ export default function App() {
 
   return (
     <WebSocketProvider>
+    <CodexProvider>
     <div className="min-h-screen bg-dark text-white relative">
       {/* Background Purple Rabbit */}
       <div className="fixed inset-0 flex items-center justify-center pointer-events-none z-0">
@@ -379,6 +382,8 @@ export default function App() {
         </Suspense>
       )}
     </div>
+    <CodexToggle />
+    </CodexProvider>
     </WebSocketProvider>
   );
 }

--- a/frontend/src/components/CodexDebugPanel.jsx
+++ b/frontend/src/components/CodexDebugPanel.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useCodex } from '../context/CodexContext.jsx';
+
+export default function CodexDebugPanel() {
+  const { logs } = useCodex();
+  return (
+    <div className="bg-black/80 text-gray-200 p-3 rounded shadow max-h-96 overflow-y-auto text-xs font-mono">
+      <div className="font-bold mb-2">Codex Debug</div>
+      {logs.length === 0 && <div className="text-gray-500">No logs</div>}
+      {logs.slice().reverse().map((l, idx) => (
+        <div key={idx} className="mb-1">
+          <span className="text-purple-400">{new Date(l.ts).toLocaleTimeString()}</span>{' '}
+          <span className="text-teal-300">{l.symbol}</span>{' '}
+          <span className="text-gray-400">{l.reason}</span>{' '}
+          <span className="text-pink-300">{l.value}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/context/CodexContext.jsx
+++ b/frontend/src/context/CodexContext.jsx
@@ -1,0 +1,60 @@
+import React, { createContext, useContext, useRef, useState } from 'react';
+
+const CodexContext = createContext(null);
+
+export const useCodex = () => {
+  const ctx = useContext(CodexContext);
+  if (!ctx) throw new Error('useCodex must be used within CodexProvider');
+  return ctx;
+};
+
+export const CodexProvider = ({ children }) => {
+  const logsRef = useRef([]);
+  const lastPctRef = useRef({});
+  const trendRef = useRef({});
+  const [logs, setLogs] = useState([]);
+
+  const appendLog = (symbol, reason, value) => {
+    const entry = { ts: Date.now(), symbol, reason, value };
+    logsRef.current.push(entry);
+    if (logsRef.current.length > 100) {
+      logsRef.current = logsRef.current.slice(-100);
+    }
+    setLogs([...logsRef.current]);
+  };
+
+  const process = (symbol, pct, opts = {}) => {
+    const minDelta = typeof opts.minDeltaToUpdate === 'number' ? opts.minDeltaToUpdate : 0.1;
+    const trendWindow = typeof opts.trendWindow === 'number' ? opts.trendWindow : 5;
+
+    const last = lastPctRef.current[symbol] ?? 0;
+    const delta = Math.abs(pct - last);
+    if (delta < minDelta) {
+      appendLog(symbol, 'minDeltaToUpdate', delta.toFixed(4));
+      return { shouldUpdate: false, trendScore: trendRef.current[symbol]?.score || 0 };
+    }
+
+    lastPctRef.current[symbol] = pct;
+
+    const arr = trendRef.current[symbol]?.arr || [];
+    arr.push(pct);
+    if (arr.length > trendWindow) arr.shift();
+    const score = arr.reduce((a, b) => a + b, 0);
+    trendRef.current[symbol] = { arr, score };
+    appendLog(symbol, 'update', pct.toFixed(4));
+    return { shouldUpdate: true, trendScore: score };
+  };
+
+  const contextValue = {
+    process,
+    logs,
+  };
+
+  return (
+    <CodexContext.Provider value={contextValue}>
+      {children}
+    </CodexContext.Provider>
+  );
+};
+
+export default CodexContext;


### PR DESCRIPTION
## Summary
- add CodexContext with token logs, minDeltaToUpdate rule, and trend score tracking
- expose CodexDebugPanel with toggle
- apply min-delta filtering and trend score in 1-min gainers table
- wire context into app

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a043e272108329881a2b8797926d62