### PR TITLE
Add volatility-based watchlist risk analysis

### DIFF
--- a/backend/test_watchlist_insights.py
+++ b/backend/test_watchlist_insights.py
@@ -21,6 +21,16 @@ class TestSmartWatchlistInsights(unittest.TestCase):
         result = smart_watchlist_insights(mem)
         self.assertIn("large-cap tokens", result)
 
+    def test_volatility_alert_and_suggestion(self):
+        mem = Memory()
+        mem.add("User added BTC to their watchlist at $100")
+        mem.add("BTC is now at $110 (10.00%)")
+        mem.add("BTC is now at $90 (-18.18%)")
+        mem.add("BTC is now at $105 (16.67%)")
+        result = smart_watchlist_insights(mem)
+        self.assertIn("highly volatile", result)
+        self.assertIn("stop-loss", result)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- calculate per-symbol volatility from watchlist updates
- emit high-volatility risk alerts and management suggestions
- test insights for volatility warnings

## Testing
- `cd backend && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0445e4b888329b072b40346f41a64

## Summary by Sourcery

Add volatility-based risk evaluation to watchlist insights by computing per-symbol price-change standard deviation and emitting high-volatility alerts with management suggestions.

New Features:
- Compute volatility as the standard deviation of percentage deltas for each watchlist symbol
- Emit high-volatility risk alerts when computed volatility exceeds threshold
- Generate suggestions to consider stop-loss or hedging for volatile symbols

Tests:
- Add unit test to verify high-volatility alerts and suggestions are produced