### PR TITLE
Streamlined startup logs and added port utility tests

### DIFF
--- a/backend/test_utils.py
+++ b/backend/test_utils.py
@@ -1,0 +1,30 @@
+import socket
+import pytest
+
+from utils import find_available_port
+
+
+def test_find_available_port_returns_free_port():
+    port = find_available_port(start_port=5500, max_attempts=5)
+    sock = socket.socket()
+    try:
+        sock.bind(('0.0.0.0', port))
+    finally:
+        sock.close()
+    assert port >= 5500
+
+
+def test_find_available_port_raises_when_exhausted():
+    start_port = 5600
+    max_attempts = 3
+    sockets = []
+    for i in range(max_attempts):
+        s = socket.socket()
+        s.bind(('0.0.0.0', start_port + i))
+        sockets.append(s)
+    try:
+        with pytest.raises(RuntimeError):
+            find_available_port(start_port=start_port, max_attempts=max_attempts)
+    finally:
+        for s in sockets:
+            s.close()


### PR DESCRIPTION
## Summary
- prefix backend and frontend logs in startup script for clearer terminal output
- ensure startup cleanup terminates log tailing processes
- test dynamic port selection utility for success and error cases

## Testing
- `pip install -r backend/requirements.txt`
- `cd backend && pytest -q`
- `timeout 10 ./start_app.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a04493293c8329a3942c02efb0a3b2

## Summary by Sourcery

Streamline startup logging by prefixing backend and frontend logs and ensure cleanup terminates log tailing processes, and add tests for the dynamic port selection utility.

Bug Fixes:
- Ensure startup cleanup stops background log tailing processes to prevent leftovers

Enhancements:
- Prefix backend and frontend log lines in the startup script for clearer terminal output

Tests:
- Add tests for find_available_port utility covering both available port selection and exhaustion scenarios