### PR TITLE
feat: improve startup port handling

### DIFF
--- a/start_app.sh
+++ b/start_app.sh
@@ -185,6 +185,6 @@ npx concurrently \
   --kill-others \
   --names "backend,frontend" \
   --prefix-colors "magenta,cyan" \
-  "cd backend && python3 app.py --port ${BACKEND_PORT}" \
+  "cd backend && PORT=${BACKEND_PORT} python3 app.py" \
   "cd frontend && VITE_API_URL=${API_BASE} VITE_WS_URL=${SOCKET_URL} npm run dev -- --port ${FRONTEND_PORT}"
 


### PR DESCRIPTION
## Summary
- add robust port probing and port picking helpers
- support `--clean` flag to free default dev ports
- ensure backend port remains free before launch and print selected URLs

## Testing
- `bash -n start_app.sh`
- `./smoke_test.sh` *(fails: request failed: /api/health)*
- `timeout 15 ./start_app.sh --clean` *(fails: lsof: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0910d60fc8329bbcc10d9f479ddce

## Summary by Sourcery

Use robust port probing to dynamically pick and validate free ports, support a cleanup option to free default ports, and streamline backend and frontend startup with concurrently while displaying the real service URLs.

New Features:
- Introduce is_port_free and pick_port helpers for robust port availability checking
- Add a --clean flag to kill default development ports (5001 and 5173) before startup

Enhancements:
- Dynamically select free backend (5001–5010) and frontend (5173–5183) ports at startup with automatic fallback
- Replace manual log tailing and PID management with concurrently to launch and manage backend and frontend processes
- Print the actual API, WebSocket, and frontend URLs based on the selected ports