### PR TITLE
Track watchlist entries from add time

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -757,24 +757,14 @@ def process_product_data(products, stats_data, ticker_data):
     return processed_data
 
 def format_crypto_data(crypto_data):
-    """Format 3-minute crypto data for frontend with detailed price tracking.
-    Includes legacy aliases (change3m, prev3m, current_price, initial_price_3min, price_change_percentage_3min)
-    so older frontend code continues to work.
-    """
+    """Format 3-minute crypto data for frontend with concise keys."""
     return [
         {
             "symbol": coin["symbol"],
-            # canonical keys used by newer components
             "current": coin["current_price"],
             "initial_3min": coin["initial_price_3min"],
             "gain": coin["price_change_percentage_3min"],
             "interval_minutes": round(coin["actual_interval_minutes"], 1),
-            # aliases for backward-compat with earlier frontend mapping
-            "current_price": coin["current_price"],
-            "initial_price_3min": coin["initial_price_3min"],
-            "price_change_percentage_3min": coin["price_change_percentage_3min"],
-            "change3m": coin["price_change_percentage_3min"],
-            "prev3m": coin["initial_price_3min"],
         }
         for coin in crypto_data
     ]


### PR DESCRIPTION
## Summary
- track price and percent change from the moment a coin is added to the watchlist
- log visible watchlist symbols and drop the surrounding border
- slim down backend `format_crypto_data` to return only the expected keys

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a36e640bd0832989859b3cbc81db3c

## Summary by Sourcery

Track the price at which each coin is added to the watchlist, calculate and display change since addition, log visible symbols for analytics, remove the component border, and simplify backend crypto data formatting to only return concise keys.

New Features:
- Track price and percent change for each coin from the moment it is added to the watchlist
- Auto-capture add-time price for existing symbols when their price becomes available
- Log visible watchlist symbols on each render for debugging and analytics

Enhancements:
- Remove surrounding border from the watchlist component
- Slim down backend format_crypto_data to return only the expected concise keys